### PR TITLE
Update createk8scluster.md

### DIFF
--- a/hints/createk8scluster.md
+++ b/hints/createk8scluster.md
@@ -25,7 +25,7 @@ az aks create --name $KUBE_NAME --resource-group $KUBE_GROUP --node-count 3 --ge
 ```
 on the command line, if you have to use the given service principal (because you are not allowed to create services principals in Azure AD), add the following parameters
 ```
---client-secret HEREBESECRET --service-principal HEREBEAPPID
+--client-secret <service principal secret / password> --service-principal <service principal app id>
 
 
 ```


### PR DESCRIPTION
The convention is to use <> to surround required input in shell commands.  
I had to explain the command several times when holding the workshop, as my attendees ran into issues around the automatic creation of the service principal for the AKS cluster.  
I believe that this small change will go a long way to making this easier to understand for some.